### PR TITLE
STORM_B (feat): add edit action for show manual order

### DIFF
--- a/app/controllers/dredd/manual_orders_controller.rb
+++ b/app/controllers/dredd/manual_orders_controller.rb
@@ -2,7 +2,7 @@
 
 module Dredd
   class ManualOrdersController < BaseController
-    before_action :set_manual_order, only: [:show, :destroy]
+    before_action :set_manual_order, only: [:show, :edit, :update, :destroy]
 
     def index
       @pagy, @manual_orders = pagy(ManualOrder.all, items: 20)
@@ -14,6 +14,8 @@ module Dredd
       @manual_order = ManualOrder.new
     end
 
+    def edit; end
+
     def create
       @manual_order = ManualOrder.new(manual_order_params)
 
@@ -21,6 +23,14 @@ module Dredd
         redirect_to dredd_manual_orders_path, notice: 'Manual order was successfully created' # rubocop:disable Rails/I18nLocaleTexts
       else
         render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      if @manual_order.update(manual_order_params)
+        redirect_to dredd_manual_order_path(@manual_order), notice: 'Manual Order was successfully updated.' # rubocop:disable Rails/I18nLocaleTexts
+      else
+        render :edit, status: :unprocessable_entity
       end
     end
 
@@ -32,10 +42,9 @@ module Dredd
     private
 
     def manual_order_params
-      params.require(:manual_order).permit(:first_name, :last_name, :email, :phone_number, :app_contact, :count,
+      params.require(:manual_order).permit(:print_code, :first_name, :last_name, :email, :phone_number, :app_contact, :count,
                                            :price_for_modeling, :price_for_printing, :prepaid_expense, :status, :total_price, :comment,
-                                           :print_material, :print_color, :deadline, :printing_time_for_one_item,
-                                           printed_on_printers: [])
+                                           :print_material, :print_color, :deadline, :printing_time_for_one_item, printed_on_printers: [])
     end
 
     def set_manual_order

--- a/app/views/dredd/manual_orders/_form.html.erb
+++ b/app/views/dredd/manual_orders/_form.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "dredd/shared/errors", locals: { resource: @manual_order } %>
-<%= form_with model: [:dredd, @manual_order], url: dredd_manual_orders_path, class: "form-grid-single" do |form| %>
+<%= form_with model: [:dredd, @manual_order], class: "form-grid-single" do |form| %>
    <div class="form-grid-single w-10/12">
     <div class="flex space-x-4">
       <div class="form-group">
@@ -83,7 +83,7 @@
       <%= form.text_area :comment, placeholder: "Please input", class: "w-full p-2" %>
     </div>
     <div class="form-group">
-      <%= form.submit "Create Manual Order", class: "button w-full md:max-w-[212px]" %>
+      <%= form.submit "Save", class: "button w-full md:max-w-[212px]" %>
     </div>
   </div>
 <% end %>

--- a/app/views/dredd/manual_orders/_manual_order.html.erb
+++ b/app/views/dredd/manual_orders/_manual_order.html.erb
@@ -60,9 +60,9 @@
     <% end %>
   </td>
   <td class="px-6 py-4 font-medium whitespace-nowrap space-x-4 flex" scope="row">
-    <div class="text-black bg-primary p-1.5 rounded-2xl text-black">
+    <%= link_to edit_dredd_manual_order_path(manual_order), class: "text-black bg-primary p-1.5 rounded-2xl text-black" do %>
       EDIT
-    </div>
+    <% end %>
     <%= button_to dredd_manual_order_path(manual_order), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-black bg-danger p-1.5 rounded-2xl text-black" do %>
       DESTROY
     <% end %>

--- a/app/views/dredd/manual_orders/edit.html.erb
+++ b/app/views/dredd/manual_orders/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="lg:px-24 max-w-screen-2xl mt-16 mx-auto w-full">
+  <div class="mt-9">
+    <div class="text-2xl font-medium">
+      <h2>Edit <%= @manual_order.print_code %></h2>
+    </div>
+    <%= render partial: 'form', locals: { manual_order: @manual_order } %>
+  </div>
+</div>

--- a/app/views/dredd/manual_orders/show.html.erb
+++ b/app/views/dredd/manual_orders/show.html.erb
@@ -111,4 +111,5 @@
       </div>
     </div>
   </div>
+  <%= link_to "Edit manual order", edit_dredd_manual_order_path(@manual_order), class: "button w-80" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :product_categories, except: [:update]
     resources :feedback_calls, only: [:index]
     resources :orders, only: [:index, :show]
-    resources :manual_orders, except: [:update]
+    resources :manual_orders
   end
   devise_for :users, controllers: { registrations: 'users/registrations' }
 

--- a/spec/request/dredd/manual_orders_spec.rb
+++ b/spec/request/dredd/manual_orders_spec.rb
@@ -32,6 +32,8 @@ describe '/dredd/manual_orders', type: :request do
       expect(response.body).to include('CREATED AT')
       expect(response.body).to include('ACTIONS')
       expect(response.body).to include(new_dredd_manual_order_path)
+      expect(response.body).to include(edit_dredd_manual_order_path(manual_order_first))
+      expect(response.body).to include(edit_dredd_manual_order_path(manual_order_second))
       expect(response.body).to include('Create Manual Order')
     end
   end
@@ -58,7 +60,7 @@ describe '/dredd/manual_orders', type: :request do
       expect(response.body).to include('Printed on printers')
       expect(response.body).to include('Deadline')
       expect(response.body).to include('Comment')
-      expect(response.body).to include('Create Manual Order"')
+      expect(response.body).to include('Create Manual Order')
     end
   end
 
@@ -91,6 +93,8 @@ describe '/dredd/manual_orders', type: :request do
       expect(response.body).to include('PLA')
       expect(response.body).to include('Ender-3 Pro, Ultimaker')
       expect(response.body).to include('Comment')
+      expect(response.body).to include('Edit manual order')
+      expect(response.body).to include(edit_dredd_manual_order_path(manual_order))
     end
   end
 
@@ -134,6 +138,59 @@ describe '/dredd/manual_orders', type: :request do
       expect(manual_order.printed_on_printers).to include('Ender-3 Pro')
       expect(manual_order.comment).to eq('Just for fun')
       expect(manual_order.deadline).not_to be_nil
+    end
+  end
+
+  describe 'PUT /dredd/manual_orders/:id' do
+    let!(:manual_order) do
+      create(:manual_order,
+             first_name: 'John', last_name: 'Doe', total_price: 500,
+             phone_number: '0673646509', email: '3d.storm.des@gmail.com',
+             print_material: 'ABS', app_contact: 'viber', comment: 'Comment')
+    end
+
+    let(:params) do
+      {
+        manual_order: {
+          first_name: 'John',
+          last_name: 'Doe',
+          phone_number: '+380673646509',
+          email: '3d.storm.des@gmail.com',
+          app_contact: 'telegram',
+          price_for_modeling: '100',
+          price_for_printing: '200',
+          count: '2',
+          total_price: '600',
+          prepaid_expense: '200',
+          print_color: 'White',
+          print_material: 'PLA',
+          printed_on_printers: ['Ender-3Pro, Guider, Custom'],
+          comment: 'New comment'
+        }
+      }
+    end
+
+    it 'update manual order' do
+      expect do
+        put(dredd_manual_order_path(manual_order), params:)
+        manual_order.reload
+      end.to change(ManualOrder, :count).by(0) # rubocop:disable RSpec/ChangeByZero
+          .and change(manual_order, :app_contact).from('viber').to('telegram')
+          .and change(manual_order, :phone_number).from('0673646509').to('+380673646509')
+          .and change(manual_order, :comment).from('Comment').to('New comment')
+          .and change(manual_order, :total_price).from(500.0).to(600.0)
+          .and change(manual_order, :print_material).from('ABS').to('PLA')
+          .and change(manual_order, :print_color).from(nil).to('White')
+          .and change(manual_order, :prepaid_expense).from(nil).to(200.0)
+          .and change(manual_order, :price_for_printing).from(nil).to(200.0)
+          .and change(manual_order, :price_for_modeling).from(nil).to(100.0)
+          .and change(manual_order, :count).from(nil).to(2)
+
+      expect(manual_order.full_name).to eq('John Doe')
+      expect(manual_order.printed_on_printers).to eq('["Ender-3Pro, Guider, Custom"]')
+      expect(response).to redirect_to(dredd_manual_order_path(manual_order))
+      follow_redirect!
+      expect(response.body).to include('Manual Order was successfully updated.')
     end
   end
 


### PR DESCRIPTION
#### In this PR I added Edit page for manual order (picture 1)

##### Picture 1

<img width="1392" alt="image" src="https://github.com/Shabaldas/storm_esbuild/assets/33484674/4e93210e-eda4-47b6-bd4d-a4d281f3d2df">
 