### PR TITLE
STORM_B (feat): add modeller to manual orders

### DIFF
--- a/app/controllers/dredd/manual_orders_controller.rb
+++ b/app/controllers/dredd/manual_orders_controller.rb
@@ -5,8 +5,8 @@ module Dredd
     before_action :set_manual_order, only: [:edit, :update, :destroy]
 
     def index
-      @q = ManualOrder.order(print_code: :asc).ransack(params[:q])
-      @pagy, @manual_orders = pagy(@q.result(distinct: true), items: 20)
+      @q = ManualOrder.order(print_code: :desc).ransack(params[:q])
+      @pagy, @manual_orders = pagy(@q.result(distinct: true), items: 30)
     end
 
     def new
@@ -42,7 +42,7 @@ module Dredd
 
     def manual_order_params
       params.require(:manual_order).permit(:print_code, :first_name, :last_name, :email, :phone_number, :app_contact, :count,
-                                           :price_for_modeling, :price_for_printing, :prepaid_expense, :status, :total_price, :comment,
+                                           :price_for_modeling, :price_for_printing, :modeller, :prepaid_expense, :status, :total_price, :comment,
                                            :print_material, :print_color, :deadline, :printing_time_for_one_item, :quality, :infill)
     end
 

--- a/app/lib/database_seeds/dummy/manual_orders_seed.rb
+++ b/app/lib/database_seeds/dummy/manual_orders_seed.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DatabaseSeeds
+  module Dummy
+    class ManualOrdersSeed
+      def execute
+        return if Rails.env.production?
+
+        25.times do
+          FactoryBot.create :manual_order
+        end
+      end
+    end
+  end
+end

--- a/app/models/manual_order.rb
+++ b/app/models/manual_order.rb
@@ -2,8 +2,10 @@
 
 class ManualOrder < ApplicationRecord
   PRINTING_COLORS = [
-    'Black', 'White', 'Transparent', 'Natural', 'Orange', 'Grey'
+    'Black', 'White', 'Grey', 'Transparent', 'Blue,', 'Yellow', 'Violet', 'Natural', 'Orange'
   ].freeze
+
+  MODELLERS = ['Andriy', 'Anton'].freeze
 
   before_create :set_print_code
 

--- a/app/views/dredd/manual_orders/_form.html.erb
+++ b/app/views/dredd/manual_orders/_form.html.erb
@@ -31,6 +31,10 @@
         <%= form.text_field :price_for_modeling, placeholder: t("dredd.manual_orders.please_input") %>
       </div>
       <div class="form-group">
+        <%= form.label t("dredd.manual_orders.modeller"), class: "form-label" %>
+        <%= form.select :modeller, ManualOrder::MODELLERS, { include_blank: t("dredd.manual_orders.select") } %>
+      </div>
+      <div class="form-group">
         <%= form.label t("dredd.manual_orders.price_for_printing"), class: "form-label" %>
         <%= form.text_field :price_for_printing, placeholder: t("dredd.manual_orders.please_input") %>
       </div>

--- a/config/locales/en/dredd.en.yml
+++ b/config/locales/en/dredd.en.yml
@@ -32,6 +32,7 @@ en:
       phone_number: "Phone number"
       app_contact: "Application contact"
       email: "email"
+      modeller: "Modeller"
       price_for_modeling: "Price for modeling"
       price_for_printing: "Price for printing"
       count: "Count"

--- a/config/locales/uk/dredd.uk.yml
+++ b/config/locales/uk/dredd.uk.yml
@@ -32,6 +32,7 @@ uk:
       phone_number: "Номер телефону"
       app_contact: "Контакт застосунку"
       email: "Електронна пошта"
+      modeller: "Моделлер"
       price_for_modeling: "Вартість моделювання"
       price_for_printing: "Вартість друку"
       count: "Кількість"

--- a/db/migrate/20230910111735_add_modeller_to_manual_order.rb
+++ b/db/migrate/20230910111735_add_modeller_to_manual_order.rb
@@ -1,0 +1,5 @@
+class AddModellerToManualOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :manual_orders, :modeller, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_130947) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_10_111735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_130947) do
     t.index ["token"], name: "index_carts_on_token", unique: true
   end
 
+  create_table "cities", force: :cascade do |t|
+    t.string "english_name", null: false
+    t.string "ukrainian_name", null: false
+    t.boolean "active", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "feedback_calls", force: :cascade do |t|
     t.string "phone_number", null: false
     t.boolean "processed", default: false
@@ -100,6 +108,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_130947) do
     t.datetime "updated_at", null: false
     t.string "quality"
     t.string "infill"
+    t.string "modeller"
   end
 
   create_table "modeling_orders", force: :cascade do |t|
@@ -161,6 +170,32 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_130947) do
     t.string "size"
     t.float "weight"
     t.float "volume"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "printer_maintenances", force: :cascade do |t|
+    t.bigint "printer_id", null: false
+    t.string "problem", null: false
+    t.datetime "problem_find"
+    t.string "time_for_fix"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["printer_id"], name: "index_printer_maintenances_on_printer_id"
+  end
+
+  create_table "printers", force: :cascade do |t|
+    t.string "printer_code"
+    t.string "firm"
+    t.string "model"
+    t.integer "printing_technology", default: 0
+    t.integer "state", default: 0
+    t.integer "type_mechanic", default: 0
+    t.string "table_size"
+    t.decimal "price_for_printer", precision: 8, scale: 2, default: "0.0"
+    t.datetime "bought"
+    t.string "comment"
+    t.string "by_for_upgrade"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "stimulus-rails-nested-form": "^4.1.0",
     "tailwindcss": "^3.3.3",
     "tailwindcss-stimulus-components": "^3.0.4",
-    "three": "^0.155.0",
+    "three": "^0.153.0",
     "tom-select": "^2.2.2"
   },
   "scripts": {

--- a/spec/factories/manual_orders.rb
+++ b/spec/factories/manual_orders.rb
@@ -4,6 +4,11 @@ FactoryBot.define do
     last_name { Faker::Name.name }
     phone_number { '+380976404050' }
     email { Faker::Internet.email }
-    total_price { '500' }
+    app_contact { ManualOrder.app_contacts.values.sample }
+    status { ManualOrder.statuses.values.sample }
+    price_for_modeling { rand(100..500).to_s }
+    price_for_printing { rand(100..500).to_s }
+    print_color { ManualOrder::PRINTING_COLORS.sample }
+    total_price { rand(500..1000).to_s }
   end
 end

--- a/spec/helpers/dredd/manual_order_helper_spec.rb
+++ b/spec/helpers/dredd/manual_order_helper_spec.rb
@@ -2,10 +2,10 @@ describe Dredd::ManualOrderHelper do
   describe '#app_icon_contact' do
     delegate :app_icon_contact, to: :helper
 
-    context 'when app contact is not persisted' do
-      let!(:manual_order) { create(:manual_order) }
+    context 'when app contact is google' do
+      let!(:manual_order) { create(:manual_order, app_contact: :google) }
 
-      it 'returns google icon by default' do
+      it 'returns google icon' do
         expect(app_icon_contact(manual_order.app_contact)).to eq('google_icon')
       end
     end

--- a/spec/lib/database_seeds/dummy/manual_orders_seed_spec.rb
+++ b/spec/lib/database_seeds/dummy/manual_orders_seed_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe DatabaseSeeds::Dummy::ManualOrdersSeed do
+  describe '#execute' do
+    context 'when executing seed' do
+      before { described_class.new.execute }
+
+      it 'creates 25 manual orders' do
+        expect(ManualOrder.count).to eq(25)
+      end
+    end
+  end
+end

--- a/spec/request/dredd/manual_orders_spec.rb
+++ b/spec/request/dredd/manual_orders_spec.rb
@@ -46,6 +46,7 @@ describe '/dredd/manual_orders', type: :request do
       expect(response.body).to include('Phone number')
       expect(response.body).to include('Application contact')
       expect(response.body).to include('Email')
+      expect(response.body).to include('Modeller')
       expect(response.body).to include('Price for modeling')
       expect(response.body).to include('Price for printing')
       expect(response.body).to include('Quality')
@@ -72,6 +73,7 @@ describe '/dredd/manual_orders', type: :request do
             phone_number: '0673646509',
             email: 'john@gmail.com',
             app_contact: 'viber',
+            modeller: 'Anton',
             price_for_modeling: '100',
             price_for_printing: '200',
             count: '2',
@@ -93,6 +95,7 @@ describe '/dredd/manual_orders', type: :request do
       expect(manual_order.phone_number).to eq('0673646509')
       expect(manual_order.email).to eq('john@gmail.com')
       expect(manual_order.app_contact).to eq('viber')
+      expect(manual_order.modeller).to eq('Anton')
       expect(manual_order.price_for_modeling.to_s).to eq('100.0')
       expect(manual_order.price_for_printing.to_s).to eq('200.0')
       expect(manual_order.count).to eq(2)
@@ -112,7 +115,8 @@ describe '/dredd/manual_orders', type: :request do
       create(:manual_order,
              first_name: 'John', last_name: 'Doe', total_price: 500,
              phone_number: '0673646509', email: '3d.storm.des@gmail.com',
-             quality: '0.1mm', infill: '50%',
+             quality: '0.1mm', infill: '50%', print_color: 'Natural',
+             price_for_modeling: '50', price_for_printing: '150',
              print_material: 'ABS', app_contact: 'viber', comment: 'Comment')
     end
 
@@ -124,6 +128,7 @@ describe '/dredd/manual_orders', type: :request do
           phone_number: '+380673646509',
           email: '3d.storm.des@gmail.com',
           app_contact: 'telegram',
+          modeller: 'Andriy',
           price_for_modeling: '100',
           price_for_printing: '200',
           count: '2',
@@ -148,10 +153,11 @@ describe '/dredd/manual_orders', type: :request do
           .and change(manual_order, :comment).from('Comment').to('New comment')
           .and change(manual_order, :total_price).from(500.0).to(600.0)
           .and change(manual_order, :print_material).from('ABS').to('PLA')
-          .and change(manual_order, :print_color).from(nil).to('White')
+          .and change(manual_order, :print_color).from('Natural').to('White')
           .and change(manual_order, :prepaid_expense).from(nil).to(200.0)
-          .and change(manual_order, :price_for_printing).from(nil).to(200.0)
-          .and change(manual_order, :price_for_modeling).from(nil).to(100.0)
+          .and change(manual_order, :modeller).from(nil).to('Andriy')
+          .and change(manual_order, :price_for_modeling).from(50).to(100.0)
+          .and change(manual_order, :price_for_printing).from(150).to(200.0)
           .and change(manual_order, :quality).from('0.1mm').to('0.2mm')
           .and change(manual_order, :infill).from('50%').to('100%')
           .and change(manual_order, :count).from(nil).to(2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,10 +891,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.155.0:
-  version "0.155.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.155.0.tgz#cca9b8ad817830c8b4fdd8f0d9a12a2e413a2672"
-  integrity sha512-sNgCYmDijnIqkD/bMfk+1pHg3YzsxW7V2ChpuP6HCQ8NiZr3RufsXQr8M3SSUMjW4hG+sUk7YbyuY0DncaDTJQ==
+three@^0.153.0:
+  version "0.153.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.153.0.tgz#d8f2aab7b49ae4ac947fd0e24cebec11378758f0"
+  integrity sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
#### In this PR I did next: 

- [x] Add model to manual orders (picure 1.)
- [x] Downgrade theejs version from 0.155 to 0.153;
- [x] Write seed for manual orders

##### Picure 1.
<img width="836" alt="image" src="https://github.com/Shabaldas/storm_esbuild/assets/33484674/472d789f-1c52-4e42-8b31-ff33b23e66dc">

