### PR TITLE
(feat): update bullet to new version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 group :development, :test do
   gem 'awesome_print'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'bullet'
+  gem 'bullet', '~> 7.1.5'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'faker'
@@ -81,7 +81,6 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'shoulda-matchers'
   gem 'webmock'
-  gem 'bullet'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    bullet (7.0.7)
+    bullet (7.1.5)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
@@ -594,7 +594,7 @@ DEPENDENCIES
   aws-sdk-s3
   bcrypt_pbkdf (>= 1.0, < 2.0)
   bootsnap
-  bullet
+  bullet (~> 7.1.5)
   byebug
   canonical-rails!
   capistrano (~> 3.11)


### PR DESCRIPTION
This pull request includes changes to the `Gemfile` to manage the version of the `bullet` gem and remove its redundancy in the development and test environments. 

Here are the key changes:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL69-R69): The version of the `bullet` gem has been specified to be '~> 7.1.5' under the development and test environments. Previously, it was not version controlled.
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL84): The `bullet` gem was removed from the development group as it was redundant. It was already included in the development and test group.