### PR TITLE
(feat): update active storage gem

### DIFF
--- a/db/migrate/20240126164924_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20240126164924_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,0 +1,22 @@
+# This migration comes from active_storage (originally 20190112182829)
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  def up
+    return unless table_exists?(:active_storage_blobs)
+
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string
+
+      if configured_service = ActiveStorage::Blob.service.name
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+  end
+
+  def down
+    return unless table_exists?(:active_storage_blobs)
+
+    remove_column :active_storage_blobs, :service_name
+  end
+end

--- a/db/migrate/20240126164925_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20240126164925_create_active_storage_variant_records.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20191206030411)
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+  def change
+    return unless table_exists?(:active_storage_blobs)
+
+    # Use Active Record's configured type for primary key
+    create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
+      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
+
+    def blobs_primary_key_type
+      pkey_name = connection.primary_key(:active_storage_blobs)
+      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+      pkey_column.bigint? ? :bigint : pkey_column.type
+    end
+end

--- a/db/migrate/20240126164926_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20240126164926_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,0 +1,8 @@
+# This migration comes from active_storage (originally 20211119233751)
+class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
+  def change
+    return unless table_exists?(:active_storage_blobs)
+
+    change_column_null(:active_storage_blobs, :checksum, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_17_175655) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_26_164926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,10 +29,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_17_175655) do
     t.string "filename", null: false
     t.string "content_type"
     t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
     t.datetime "created_at", null: false
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 


### PR DESCRIPTION
This pull request primarily involves database migrations related to Active Storage in Rails. The changes include adding a `service_name` column to the `active_storage_blobs` table, creating a new `active_storage_variant_records` table, and making the `checksum` column in the `active_storage_blobs` table nullable. Additionally, the schema version has been updated.

Database migrations:

* [`db/migrate/20240126164924_add_service_name_to_active_storage_blobs.active_storage.rb`](diffhunk://#diff-0bf0fe8e0f98627086d9784524bdabd6eb3a25fe55448299a247cb91edcee244R1-R22): A new `service_name` column was added to the `active_storage_blobs` table. This column is populated with the name of the configured service for Active Storage, if any. It is then set to not allow null values.

* [`db/migrate/20240126164925_create_active_storage_variant_records.active_storage.rb`](diffhunk://#diff-25fcff0f7f0ddb994ada11be300188136396d715a63e8a6e56dcabadfa91825cR1-R27): A new table, `active_storage_variant_records`, was created. This table includes a foreign key to the `active_storage_blobs` table, a `variation_digest` string column, and a unique index on the combination of `blob_id` and `variation_digest`.

* [`db/migrate/20240126164926_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb`](diffhunk://#diff-9a9f63fdd2d79c04ed4eca288309342ccede364f464eacf067ee216b78c9eb67R1-R8): The `checksum` column in the `active_storage_blobs` table was changed to allow null values.

Schema version update:

* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13): The schema version was updated to reflect the latest migration. Also, the `service_name` column in the `active_storage_blobs` table was moved to a different position. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L32-R35)