### PR TITLE
(feat): add sitemap generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'sidekiq', '~> 7.0.0'
 gem 'sprockets-rails'
 gem 'stimulus-rails'
 gem 'simple_form'
+gem 'sitemap_generator'
 gem 'sentry-ruby'
 gem 'sentry-rails'
 gem "sentry-sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,6 +523,8 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.6)
       tilt (~> 2.0)
+    sitemap_generator (6.3.0)
+      builder (~> 3.0)
     spring (4.1.1)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
@@ -656,6 +658,7 @@ DEPENDENCIES
   sidekiq-cron
   simple_form
   simplecov
+  sitemap_generator
   spring
   sprockets-rails
   stimulus-rails

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,55 @@
+# Set the host name for URL creation
+SitemapGenerator::Sitemap.default_host = 'https://3dstorm.com.ua/'
+
+SitemapGenerator::Sitemap.create do
+  add '/printing', changefreq: 'weekly', priority: 0.9
+  add '/rendering', changefreq: 'weekly', priority: 0.9
+  add '/modeling', changefreq: 'weekly', priority: 0.9
+
+  City.find_each do |city|
+    add printing_city_path(city.english_name.downcase), lastmod: city.updated_at
+  end
+
+  City.find_each do |city|
+    add rendering_city_path(city.english_name.downcase), lastmod: city.updated_at
+  end
+
+  City.find_each do |city|
+    add modeling_city_path(city.english_name.downcase), lastmod: city.updated_at
+  end
+
+  City.find_each do |city|
+    add printing_city_path(city.ukrainian_name.downcase), lastmod: city.updated_at
+  end
+
+  City.find_each do |city|
+    add rendering_city_path(city.ukrainian_name.downcase), lastmod: city.updated_at
+  end
+
+  City.find_each do |city|
+    add modeling_city_path(city.ukrainian_name.downcase), lastmod: city.updated_at
+  end
+  
+  # Put links creation logic here.
+  #
+  # The root path '/' and sitemap index file are added automatically for you.
+  # Links are added to the Sitemap in the order they are specified.
+  #
+  # Usage: add(path, options={})
+  #        (default options are used if you don't specify)
+  #
+  # Defaults: :priority => 0.5, :changefreq => 'weekly',
+  #           :lastmod => Time.now, :host => default_host
+  #
+  # Examples:
+  #
+  # Add '/articles'
+  #
+  #   add articles_path, :priority => 0.7, :changefreq => 'daily'
+  #
+  # Add all articles:
+  #
+  #   Article.find_each do |article|
+  #     add article_path(article), :lastmod => article.updated_at
+  #   end
+end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+Sitemap: https://3dstorm.com.ua/sitemap.xml.gz


### PR DESCRIPTION
This pull request primarily focuses on the implementation of a sitemap for the website, including the addition of the `sitemap_generator` gem, creation of a sitemap configuration file, and updating the `robots.txt` file to include the sitemap's URL. 

Sitemap implementation:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR47): Added the `sitemap_generator` gem to the project dependencies.
* [`config/sitemap.rb`](diffhunk://#diff-21ba41145c76352d6bc17a4ebca6f208354a31d09143d98654ad55c274e44535R1-R55): Created a new sitemap configuration file. This file sets the default host for URL creation and specifies the paths to be included in the sitemap. It also includes logic to dynamically add paths for each city in the database.
* [`public/robots.txt`](diffhunk://#diff-1dc4bea7b6827b18f8869436bd7786266d3cea8596529887ef16a027eb2e4076R2): Updated the `robots.txt` file to include the URL of the sitemap. This allows web crawlers to easily find and use the sitemap to index the website.