### PR TITLE
(feat): upgrade turbo to 8.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "sentry-delayed_job"
 gem "sentry-resque"
 gem "sentry-opentelemetry"
 gem "telegram-bot-ruby"
-gem 'turbo-rails'
+gem 'turbo-rails', '~> 2.0.0'
 
 gem 'ed25519', '>= 1.2', '< 2.0'
 gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,7 +548,7 @@ GEM
     tilt (2.3.0)
     timecop (0.9.6)
     timeout (0.4.0)
-    turbo-rails (1.3.3)
+    turbo-rails (2.0.2)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -664,7 +664,7 @@ DEPENDENCIES
   stimulus-rails
   telegram-bot-ruby
   timecop
-  turbo-rails
+  turbo-rails (~> 2.0.0)
   tzinfo-data
   web-console
   webdrivers

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= turbo_refreshes_with method: :replace, scroll: :preserve %>
 
     <%= google_analytics_head_script %>
     <%#= google_analytics_tag_head_script %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
       <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
       <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+      <%= turbo_refreshes_with method: :replace, scroll: :preserve  %>
 
       <%= google_analytics_head_script %>
       <%#= google_analytics_tag_head_script %>

--- a/app/views/layouts/checkout.html.erb
+++ b/app/views/layouts/checkout.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= turbo_refreshes_with method: :replace, scroll: :preserve %>
 
     <%#= google_analytics_head_script %>
     <%#= google_analytics_tag_head_script %>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "@hotwired/turbo-rails": "^7.2.5",
+    "@hotwired/turbo-rails": "^8.0.0",
     "@rails/activestorage": "^7.1.3",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,18 +122,18 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
 
-"@hotwired/turbo-rails@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.2.5.tgz#74fc3395a29a76df2bb8835aa88c86885cffde4c"
-  integrity sha512-F8ztmARxd/XBdevRa//HoJGZ7u+Unb0J7cQUeUP+pBvt9Ta2TJJ7a2TORAOhjC8Zgxx+LKwm/1UUHqN3ojjiGw==
+"@hotwired/turbo-rails@^8.0.0":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.2.tgz#c43d54d9346bcf14c897166556bfed92ed4c1d17"
+  integrity sha512-j+6THPc+CsaUdUXZTg6wQ+YcStO9kn6CuGzElqFxUmV/vyd1Jfm0RLZMIbaY8w9Qse7u6JBcrm4AcRxhIhYmaQ==
   dependencies:
-    "@hotwired/turbo" "^7.2.5"
+    "@hotwired/turbo" "^8.0.2"
     "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.5.tgz#2d9d6bde8a9549c3aea8970445ade16ffd56719a"
-  integrity sha512-o5PByC/mWkmTe4pWnKrixhPECJUxIT/NHtxKqjq7n9Fj6JlNza1pgxdTCJVIq+PI0j95U+7mA3N4n4A/QYZtZQ==
+"@hotwired/turbo@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.2.tgz#c31cdadfe66b98983066a94073b26fc7e15835f0"
+  integrity sha512-3K6QZkwWfosAV8zuM5bY+kKF02jp1lMQGsWfSE6wXdZBRBP3ah+Vj26YNqYtkEomBwRWA0QKhZgyJP7xOQkVEg==
 
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"


### PR DESCRIPTION
<img width="912" alt="image" src="https://github.com/Shabaldas/storm_esbuild/assets/33484674/5ef7d5ff-a2ed-458f-a859-128908531423">

This pull request mainly focuses on updating the Turbo Rails gem and its related configurations across different files. The most significant changes include updating the Turbo Rails gem version in `Gemfile` and `package.json`, and adding turbo refresh configurations in several layout files.

Gem and package updates:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL55-R55): The Turbo Rails gem version has been updated to approximately 2.0.0.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6): The Turbo Rails package version has been updated to approximately 8.0.0.

Layout changes:

* [`app/views/layouts/admin.html.erb`](diffhunk://#diff-9fc91735fae00b113814072ed1438c53d5cf484a66c6710bc1f94f6e7d48a3f1R11): Added turbo refresh configuration with replace method and scroll preservation.
* [`app/views/layouts/application.html.erb`](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebR11): Added turbo refresh configuration with replace method and scroll preservation.
* [`app/views/layouts/checkout.html.erb`](diffhunk://#diff-207c47897b26d4b089403e8ae57279f380fce0bbd37b6289aa993ec2530c11beR11): Added turbo refresh configuration with replace method and scroll preservation.