### PR TITLE
(feat): add policy to see previous orders for manager

### DIFF
--- a/app/controllers/dredd/manual_orders_controller.rb
+++ b/app/controllers/dredd/manual_orders_controller.rb
@@ -5,7 +5,7 @@ module Dredd
     before_action :set_manual_order, only: [:edit, :update, :destroy]
 
     def index
-      @q = manual_orders_for_role
+      @q = ManualOrder.order(status: :asc, print_code: :desc).ransack(params[:q]&.permit!)
       @pagy, @manual_orders = pagy(@q.result(distinct: true), items: 20)
     end
 
@@ -58,14 +58,6 @@ module Dredd
 
     def set_manual_order
       @manual_order = ManualOrder.find(params[:id])
-    end
-
-    def manual_orders_for_role
-      if current_user.manager?
-        ManualOrder.unpaid.order(status: :asc, print_code: :desc).ransack(params[:q]&.permit!)
-      else
-        ManualOrder.order(status: :asc, print_code: :desc).ransack(params[:q]&.permit!)
-      end
     end
   end
 end


### PR DESCRIPTION
This pull request includes changes to the `ManualOrdersController` in the `app/controllers/dredd/manual_orders_controller.rb` file. The changes aim to simplify the code by removing the `manual_orders_for_role` method and modifying the `index` method to directly set the `@q` instance variable.

Here are the key changes:

* [`app/controllers/dredd/manual_orders_controller.rb`](diffhunk://#diff-cada2222d0f82ca1de7f2853106559f31d5b8db3d11e16e06b722c800b9d8c7fL62-L69): Removed the `manual_orders_for_role` method which was used to set the `@q` instance variable based on the user's role. This change simplifies the code by removing the need to check the user's role.
* [`app/controllers/dredd/manual_orders_controller.rb`](diffhunk://#diff-cada2222d0f82ca1de7f2853106559f31d5b8db3d11e16e06b722c800b9d8c7fL8-R8): Modified the `index` method to directly set the `@q` instance variable using `ManualOrder.order(status: :asc, print_code: :desc).ransack(params[:q]&.permit!)`. This change simplifies the code by removing the need to call the `manual_orders_for_role` method.