### PR TITLE
(fix): link_to in main home page

### DIFF
--- a/app/views/static_pages/home_lazy.html.erb
+++ b/app/views/static_pages/home_lazy.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="w-full max-w-screen-2xl mx-auto px-7 md:px-16 lg:px-24 flex flex-col  md:flex-row mb-20 md:mb-28 gap-6 justify-between items-center">
-    <%= link_to modeling_path, class:"w-full lg:w-1/3 h-32 md:h-48 lg:h-64 block rounded-3xl bg-white relative shadow-gray-300 hover:outline hover:outline-yellow-500 transition duration-300 ease-in-out" do %>
+    <%= link_to modeling_path, data: { turbo: false }, class:"w-full lg:w-1/3 h-32 md:h-48 lg:h-64 block rounded-3xl bg-white relative shadow-gray-300 hover:outline hover:outline-yellow-500 transition duration-300 ease-in-out" do %>
       <div>
         <div class="w-16 h-16 lg:w-24 lg:h-24 absolute top-5 right-5 lg:right-1">
           <%= image_tag("icons_svg/3d_modeling_icon.svg", alt: "3d-modeling-icon") %>
@@ -50,7 +50,7 @@
         </div>
       </div>
     <% end %>
-    <%= link_to printing_path, class:"w-full lg:w-1/3 h-32 md:h-48 lg:h-64 block rounded-3xl bg-white relative shadow-gray-300 hover:outline hover:outline-yellow-500 transition duration-300 ease-in-out" do %>
+    <%= link_to printing_path, data: { turbo: false }, class:"w-full lg:w-1/3 h-32 md:h-48 lg:h-64 block rounded-3xl bg-white relative shadow-gray-300 hover:outline hover:outline-yellow-500 transition duration-300 ease-in-out" do %>
       <div>
         <div class="w-16 h-16 lg:w-24 lg:h-24 absolute top-5 right-1 lg:-right-7 ">
           <%= image_tag("icons_svg/3d_printing_icon.svg", alt: "3d-printing-icon") %>
@@ -70,7 +70,7 @@
         </div>
       </div>
     <% end %>
-    <%= link_to rendering_path, class:"w-full lg:w-1/3 h-32 md:h-48 lg:h-64 block rounded-3xl bg-white relative shadow-gray-300 hover:outline hover:outline-yellow-500 transition duration-300 ease-in-out" do %>
+    <%= link_to rendering_path, data: { turbo: false }, class:"w-full lg:w-1/3 h-32 md:h-48 lg:h-64 block rounded-3xl bg-white relative shadow-gray-300 hover:outline hover:outline-yellow-500 transition duration-300 ease-in-out" do %>
       <div>
         <div class="w-16 h-16 lg:w-24 lg:h-24 absolute top-8 right-5 lg:right-1 ">
           <%= image_tag("icons_svg/3d_rendering_icon.svg", alt: "3d-rendering-icon") %>


### PR DESCRIPTION
This pull request includes changes to the `app/views/static_pages/home_lazy.html.erb` file. The changes involve adding `data: { turbo: false }` to three link elements, specifically those that link to the `modeling_path`, `printing_path`, and `rendering_path`. This addition disables Turbo Drive for these links, which can help prevent issues with JavaScript that's not compatible with Turbo Drive.

Changes in `app/views/static_pages/home_lazy.html.erb`:

* Added `data: { turbo: false }` to the link to `modeling_path`. This disables Turbo Drive for this link.
* Added `data: { turbo: false }` to the link to `printing_path`. This disables Turbo Drive for this link.
* Added `data: { turbo: false }` to the link to `rendering_path`. This disables Turbo Drive for this link.