### PR TITLE
STORM_B (feat): add new manual order based on clinet

### DIFF
--- a/app/controllers/dredd/manual_orders_controller.rb
+++ b/app/controllers/dredd/manual_orders_controller.rb
@@ -28,9 +28,16 @@ module Dredd
         @manual_order.last_name = client&.last_name
         @manual_order.email = client&.email
         @manual_order.phone_number = client&.phone_number
+      else
+        @client = Client.new(first_name: manual_order_params[:first_name],
+                             last_name: manual_order_params[:last_name],
+                             email: manual_order_params[:email],
+                             phone_number: manual_order_params[:phone_number])
       end
 
       if @manual_order.save
+        @client.save if manual_order_params[:client_id].blank?
+
         redirect_to dredd_manual_orders_path, status: :see_other, notice: { text: 'Manual order was successfully created', icon: 'success_icon' }
       else
         return render :new_manual_order, status: :unprocessable_entity if params[:new_or_old] == 'new'

--- a/app/controllers/dredd/manual_orders_controller.rb
+++ b/app/controllers/dredd/manual_orders_controller.rb
@@ -9,7 +9,11 @@ module Dredd
       @pagy, @manual_orders = pagy(@q.result(distinct: true), items: 30)
     end
 
-    def new
+    def new_manual_order
+      @manual_order = ManualOrder.new
+    end
+
+    def new_manual_order_from_client
       @manual_order = ManualOrder.new
     end
 
@@ -18,10 +22,20 @@ module Dredd
     def create
       @manual_order = ManualOrder.new(manual_order_params)
 
+      if manual_order_params[:client_id].present?
+        client = Client.find(manual_order_params[:client_id])
+        @manual_order.first_name = client&.first_name
+        @manual_order.last_name = client&.last_name
+        @manual_order.email = client&.email
+        @manual_order.phone_number = client&.phone_number
+      end
+
       if @manual_order.save
-        redirect_to dredd_manual_orders_path, notice: { text: 'Manual order was successfully created', icon: 'success_icon' }
+        redirect_to dredd_manual_orders_path, status: :see_other, notice: { text: 'Manual order was successfully created', icon: 'success_icon' }
       else
-        render :new, status: :unprocessable_entity
+        return render :new_manual_order, status: :unprocessable_entity if params[:new_or_old] == 'new'
+
+        render :new_manual_order_from_client, status: :unprocessable_entity
       end
     end
 
@@ -43,7 +57,7 @@ module Dredd
     private
 
     def manual_order_params
-      params.require(:manual_order).permit(:print_code, :first_name, :last_name, :email, :phone_number, :app_contact, :count,
+      params.require(:manual_order).permit(:print_code, :first_name, :client_id, :last_name, :email, :phone_number, :app_contact, :count,
                                            :need_to_call_client, :price_for_modeling, :price_for_printing,
                                            :prepaid_expense, :status, :total_price, :comment, :worker_id,
                                            :print_material, :print_color, :deadline, :workflow_status,

--- a/app/views/dredd/manual_orders/_client_form.html.erb
+++ b/app/views/dredd/manual_orders/_client_form.html.erb
@@ -1,33 +1,15 @@
 <%= form_with model: [:dredd, @manual_order], class: "form-grid-single" do |form| %>
+  <div class="form-group">
+    <%= form.label t("dredd.manual_orders.select_client"), class: "form-label"  %>
+    <div class="w-10/12">
+      <%= form.select :client_id,
+              Client.all.map { |client| ["#{client.full_name} - #{client.phone_number} - #{client.nickname}", client.id] },
+              { class: "", include_blank: false },
+              { multiple: false, data: { controller: "select" }}
+      %>
+    </div>
+  </div>
   <div class="form-grid-single w-10/12">
-    <div class="flex space-x-4">
-      <div class="form-group">
-        <%= form.label t("dredd.manual_orders.first_name"), class: "form-label" %>
-        <%= form.text_field :first_name, placeholder: t("dredd.manual_orders.please_input") %>
-        <%= inline_error_for(:first_name, @manual_order) %>
-      </div>
-      <div class="form-group">
-        <%= form.label t("dredd.manual_orders.last_name"), class: "form-label" %>
-        <%= form.text_field :last_name, placeholder: t("dredd.manual_orders.please_input") %>
-        <%= inline_error_for(:last_name, @manual_order) %>
-      </div>
-    </div>
-    <div class="flex space-x-4">
-      <div class="form-group">
-        <%= form.label t("dredd.manual_orders.phone_number"), class: "form-label" %>
-        <%= form.text_field :phone_number, placeholder: t("dredd.manual_orders.please_input") %>
-        <%= inline_error_for(:phone_number, @manual_order) %>
-      </div>
-      <div class="form-group">
-        <%= form.label t("dredd.manual_orders.app_contact"), class: "form-label" %>
-        <%= form.select :app_contact, options_for_select(ManualOrder.app_contacts.keys.map {|k, v| [k.humanize.capitalize, k] }, selected: form.object.app_contact ) %>
-      </div>
-      <div class="form-group">
-        <%= form.label t("dredd.manual_orders.email"), class: "form-label" %>
-        <%= form.text_field :email, placeholder: t("dredd.manual_orders.please_input") %>
-        <%= inline_error_for(:email, @manual_order) %>
-      </div>
-    </div>
     <div class="flex space-x-4">
       <div class="form-group">
         <%= form.label t("dredd.manual_orders.price_for_modeling"), class: "form-label" %>

--- a/app/views/dredd/manual_orders/edit.html.erb
+++ b/app/views/dredd/manual_orders/edit.html.erb
@@ -10,6 +10,6 @@
       <h2><%= t("dredd.manual_orders.edit") %></h2>
       <h2><%= @manual_order.print_code %></h2>
     </div>
-    <%= render partial: 'form', locals: { manual_order: @manual_order } %>
+    <%= render partial: "form", locals: { manual_order: @manual_order, form_type: 'old' } %>
   </div>
 </div>

--- a/app/views/dredd/manual_orders/index.html.erb
+++ b/app/views/dredd/manual_orders/index.html.erb
@@ -3,7 +3,11 @@
     <div class="sidebar w-1/6 h-auto max-w-[320px] flex-col shrink-0 lg:mr-6 fixed top-0 lg:relative z-40 lg:z-10 left-0 mb-0 lg:mb-36 transform -translate-x-full lg:translate-x-0 transition duration-700 ease-in-out" data-sidebar-target="sidebarContainer" data-expanded="1">
       <div class="relative top-0 lg:sticky lg:top-[90px] h-screen lg:h-auto bg-white rounded-0 lg:rounded-3xl py-6 px-6 lg:px-8 text-zinc-500">
         <div>
-          <%= link_to t("dredd.manual_orders.manual_order"), new_dredd_manual_order_path, class: "button" %>
+          <%= link_to t("dredd.manual_orders.new_manual_order"), new_manual_order_dredd_manual_orders_path, class: "bg-stone-300 border-1 border-solid flex flex-col h-12 items-center rounded-lg text-black text-center" %>
+        </div>
+        </br>
+        <div>
+          <%= link_to t("dredd.manual_orders.new_manual_order_from_client"), new_manual_order_from_client_dredd_manual_orders_path, class: "bg-zinc border-1 border-solid flex flex-col h-12 items-center rounded-lg text-black text-center" %>
         </div>
         </br>
         <div>
@@ -70,8 +74,9 @@
   <div class="flex justify-center w-full">
     <div class="absolute p-6">
       <%= pagy_nav(@pagy).html_safe if @pagy.pages > 1 %>
-      <footer class="pt-6">
-        <%= link_to t("dredd.manual_orders.manual_order"), new_dredd_manual_order_path, class: "button w-80" %>
+      <footer class="pt-6 flex space-x-5">
+        <%= link_to t("dredd.manual_orders.new_manual_order"), new_manual_order_dredd_manual_orders_path, class: "bg-stone-300 border-1 border-solid flex flex-col h-10 items-center rounded-full text-black text-center w-80" %>
+        <%= link_to t("dredd.manual_orders.new_manual_order_from_client"), new_manual_order_from_client_dredd_manual_orders_path, class: "bg-zinc border-1 border-solid flex flex-col h-10 items-center rounded-full text-black text-center w-80" %>
       </footer>
     </div>
   </div>

--- a/app/views/dredd/manual_orders/new.html.erb
+++ b/app/views/dredd/manual_orders/new.html.erb
@@ -1,8 +1,0 @@
-<div class="lg:px-24 max-w-screen-2xl mt-16 mx-auto w-full">
-  <div class="mt-9">
-    <div class="text-2xl font-medium">
-      <h2><%= t("dredd.manual_orders.new_manual_order") %></h2>
-    </div>
-    <%= render partial: 'form', locals: { manual_order: @manual_order } %>
-  </div>
-</div>

--- a/app/views/dredd/manual_orders/new_manual_order.html.erb
+++ b/app/views/dredd/manual_orders/new_manual_order.html.erb
@@ -1,0 +1,17 @@
+<div class="lg:px-24 max-w-screen-2xl mt-16 mx-auto w-full">
+  <div class="mt-9">
+    <div class="flex space-x-5 pt-5">
+      <%= link_to dredd_manual_orders_path, class: "back-btn text-black" do %>
+        <div class="button-text flex">
+          <%= image_tag("icons_svg/chevron-left.svg", class: "h-5")%>
+          <%= t('.back') %>
+        </div>
+      <% end %>
+      <%= link_to t("dredd.manual_orders.new_manual_order_from_client"), new_manual_order_from_client_dredd_manual_orders_path, class: "bg-zinc border-1 border-solid flex flex-col items-center rounded-full text-black text-center w-72" %>
+    </div>
+    </br>
+    <div class="bg-stone-300 flex gap-10 p-4 pt-6 rounded-3xl">
+      <%= render partial: 'form', locals: { manual_order: @manual_order, form_type: 'new' } %>
+    </div>
+  </div>
+</div>

--- a/app/views/dredd/manual_orders/new_manual_order_from_client.html.erb
+++ b/app/views/dredd/manual_orders/new_manual_order_from_client.html.erb
@@ -1,0 +1,17 @@
+<div class="lg:px-24 max-w-screen-2xl mt-16 mx-auto w-full">
+  <div class="mt-9">
+    <div class="flex space-x-5 pt-5">
+      <%= link_to dredd_manual_orders_path, class: "back-btn text-black" do %>
+        <div class="button-text flex">
+          <%= image_tag("icons_svg/chevron-left.svg", class: "h-5")%>
+          <%= t('.back') %>
+        </div>
+      <% end %>
+      <%= link_to t("dredd.manual_orders.new_manual_order"), new_manual_order_dredd_manual_orders_path, class: "bg-stone-300 border-1 border-solid flex flex-col items-center rounded-full text-black text-center w-72" %>
+    </div>
+    </br>
+    <div class="bg-zinc flex gap-10 p-4 pt-6 rounded-3xl">
+      <%= render partial: 'client_form', locals: { manual_order: @manual_order, form_type: 'old' } %>
+    </div>
+  </div>
+</div>

--- a/app/views/dredd/workers/_form.html.erb
+++ b/app/views/dredd/workers/_form.html.erb
@@ -18,4 +18,4 @@
       <%= form.submit t("dredd.manual_orders.save"), class: "button w-full md:max-w-[212px]" %>
     </div>
   </div>
-  <% end %>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,7 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <%= turbo_refreshes_with method: :replace, scroll: :preserve %>
+    <%= turbo_refreshes_with method: :morph, scroll: :reset %>
 
     <%= google_analytics_head_script %>
     <%#= google_analytics_tag_head_script %>

--- a/config/locales/en/dredd.en.yml
+++ b/config/locales/en/dredd.en.yml
@@ -43,6 +43,7 @@ en:
       deadline: "Deadline"
       actions: "Actions"
     manual_orders:
+      select_client: "Select client"
       please_input: "Please input"
       first_name: "First name "
       last_name: "Last name"
@@ -73,6 +74,7 @@ en:
       link_to_model: "Link to Model"
       manual_order: "Create Manual Order"
       new_manual_order: "New Manual Order"
+      new_manual_order_from_client: "New Manual Order from Client"
       client_contact: "Client Contacts"
       printing_information: "Printing Information"
       price_information: "Price Information"

--- a/config/locales/uk/dredd.uk.yml
+++ b/config/locales/uk/dredd.uk.yml
@@ -43,6 +43,7 @@ uk:
       deadline: "Термін"
       actions: "Дії"
     manual_orders:
+      select_client: "Виберіть клієнта"
       please_input: "Будь ласка, введіть"
       first_name: "Ім'я"
       last_name: "Прізвище"
@@ -73,6 +74,7 @@ uk:
       manual_order: "Створити ручне замовлення"
       link_to_model: "Посилання на модель"
       new_manual_order: "Нове ручне замовлення"
+      new_manual_order_from_client: "Нове замовлення на сонові клієнта"
       client_contact: "Контакти клієнта"
       printing_information: "Інформація про друк"
       price_information: "Інформація про ціну"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,10 @@ Rails.application.routes.draw do
     resources :product_categories, except: [:update]
     resources :feedback_calls, only: [:index, :update, :destroy]
     resources :orders, only: [:index, :show]
-    resources :manual_orders, except: :show
+    resources :manual_orders, except: [:show, :new] do
+      get 'new_manual_order', to: 'manual_orders#new_manual_order', on: :collection
+      get 'new_manual_order_from_client', to: 'manual_orders#new_manual_order_from_client', on: :collection
+    end
     resources :modeling_orders, except: [:new, :show]
     resources :rendering_orders, except: [:new, :show]
     resources :printing_orders, except: [:new, :show]

--- a/spec/request/dredd/manual_orders_spec.rb
+++ b/spec/request/dredd/manual_orders_spec.rb
@@ -31,9 +31,9 @@ describe '/dredd/manual_orders', type: :request do
     end
   end
 
-  describe 'GET /dredd/manual_orders/new' do
+  describe 'GET /dredd/manual_orders/new_manual_order' do
     it 'display new manual order form' do
-      get new_dredd_manual_order_path
+      get new_manual_order_dredd_manual_orders_path
 
       expect(response).to be_successful
       expect(response.body).to include('New Manual Order')
@@ -42,6 +42,30 @@ describe '/dredd/manual_orders', type: :request do
       expect(response.body).to include('Phone number')
       expect(response.body).to include('Application contact')
       expect(response.body).to include('Email')
+      expect(response.body).to include('Modeller')
+      expect(response.body).to include('Price for modeling')
+      expect(response.body).to include('Price for printing')
+      expect(response.body).to include('Quality')
+      expect(response.body).to include('Infill')
+      expect(response.body).to include('Count')
+      expect(response.body).to include('Total price')
+      expect(response.body).to include('Status')
+      expect(response.body).to include('Prepaid expense')
+      expect(response.body).to include('Print material')
+      expect(response.body).to include('Print color')
+      expect(response.body).to include('Deadline')
+      expect(response.body).to include('Comment')
+      expect(response.body).to include('FOP accounting')
+      expect(response.body).to include('Save')
+    end
+  end
+
+  describe 'GET /dredd/manual_orders/new_manual_order_from_client_dredd_manual_orders_path' do
+    it 'display new manual order form' do
+      get new_manual_order_from_client_dredd_manual_orders_path
+
+      expect(response).to be_successful
+      expect(response.body).to include('Select client')
       expect(response.body).to include('Modeller')
       expect(response.body).to include('Price for modeling')
       expect(response.body).to include('Price for printing')


### PR DESCRIPTION
![image](https://github.com/Shabaldas/storm_esbuild/assets/33484674/871bd55f-09bf-4f9c-9eee-40a3abcb76e1)
![image](https://github.com/Shabaldas/storm_esbuild/assets/33484674/3873a24c-8ce9-4db3-8799-097cb7b3903a)

### COPILOT AI DESCRIPTION:
This pull request introduces significant changes to the `ManualOrdersController` and related views in the `dredd` application, with the aim of improving the manual order creation process. The main changes include the introduction of a new order creation flow that allows for the creation of a manual order from a client, the addition of client selection in the order form, and various updates to the routes, views, and locales.

Here are the most important changes:

Controller and Routes:

* [`app/controllers/dredd/manual_orders_controller.rb`](diffhunk://#diff-cada2222d0f82ca1de7f2853106559f31d5b8db3d11e16e06b722c800b9d8c7fL12-R16): Renamed the `new` action to `new_manual_order` and added a new action `new_manual_order_from_client` for creating a manual order from a client. Updated the `create` action to handle the new order creation flow and added client details to the new manual order if a client ID is present. Also, updated the `manual_order_params` to permit `:client_id`. [[1]](diffhunk://#diff-cada2222d0f82ca1de7f2853106559f31d5b8db3d11e16e06b722c800b9d8c7fL12-R16) [[2]](diffhunk://#diff-cada2222d0f82ca1de7f2853106559f31d5b8db3d11e16e06b722c800b9d8c7fR25-R38) [[3]](diffhunk://#diff-cada2222d0f82ca1de7f2853106559f31d5b8db3d11e16e06b722c800b9d8c7fL46-R60)
* [`config/routes.rb`](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5L18-R21): Added new routes `new_manual_order` and `new_manual_order_from_client` to the `manual_orders` resource.

Views:

* `app/views/dredd/manual_orders/_client_form.html.erb` and `app/views/dredd/manual_orders/_form.html.erb`: Introduced a new form for creating a manual order from a client and made updates to the existing form to handle the new order creation flow. [[1]](diffhunk://#diff-c45c17254140ef8a8e6fb4c885b6cac7c9f44c5bc9e0f95acdcbc64a7f68abe4R1-R112) [[2]](diffhunk://#diff-ab390fc766a2591537795c794b14fbdf8c178a4fa4b1a76b02a59e5b33af2c5bL1-R1) [[3]](diffhunk://#diff-ab390fc766a2591537795c794b14fbdf8c178a4fa4b1a76b02a59e5b33af2c5bR125)
* `app/views/dredd/manual_orders/edit.html.erb`, `app/views/dredd/manual_orders/index.html.erb`, `app/views/dredd/manual_orders/new.html.erb`, `app/views/dredd/manual_orders/new_manual_order.html.erb`, and `app/views/dredd/manual_orders/new_manual_order_from_client.html.erb`: Made updates to these views to handle the new order creation flow, including adding links to the new order creation actions and removing the old new action. [[1]](diffhunk://#diff-892f66367bf9bf171db7c6e778ecfd064b40a2aab081ddb174061fc7472ac108L13-R13) [[2]](diffhunk://#diff-f0533f5fa32d7d959d7da4b6e9ba61c96eee468a91a454a9c91b9927c3856effL6-R10) [[3]](diffhunk://#diff-f0533f5fa32d7d959d7da4b6e9ba61c96eee468a91a454a9c91b9927c3856effL73-R79) [[4]](diffhunk://#diff-3e6171bc4b7f2a1bd2fc36d72e1b8839a9359d04dfd4a999a6ad65bc3441ec4eL1-L8) [[5]](diffhunk://#diff-32d28b0e9aeb6fefc0e13cff1d51e2280ff1371523911f9c0b63084cd7d59f88R1-R17) [[6]](diffhunk://#diff-73ad104269da7126996c990e4993ff8aea0e74984087024503a015a569617558R1-R17)

Locales:

* `config/locales/en/dredd.en.yml` and `config/locales/uk/dredd.uk.yml`: Added translations for the new order creation actions and the client selection label. [[1]](diffhunk://#diff-f2fb54f3c54d4abef14fa6f8b00242239dd1f8b44bba0f426ea4326714b5d6c5R46) [[2]](diffhunk://#diff-f2fb54f3c54d4abef14fa6f8b00242239dd1f8b44bba0f426ea4326714b5d6c5R77) [[3]](diffhunk://#diff-1ba1f2aed8009d2a738f36289d05144a51662cdc691a870e6afbcbaf9756b556R46) [[4]](diffhunk://#diff-1ba1f2aed8009d2a738f36289d05144a51662cdc691a870e6afbcbaf9756b556R77)

Tests:

* [`spec/request/dredd/manual_orders_spec.rb`](diffhunk://#diff-8e0b3aac27142fe83213a4a466f14f8ea16c83833b14cb82cc099a7ff9f400d5L34-R36): Updated the test for the new action and added a new test for the `new_manual_order_from_client` action. [[1]](diffhunk://#diff-8e0b3aac27142fe83213a4a466f14f8ea16c83833b14cb82cc099a7ff9f400d5L34-R36) [[2]](diffhunk://#diff-8e0b3aac27142fe83213a4a466f14f8ea16c83833b14cb82cc099a7ff9f400d5R63-R86)

Other:

* [`app/views/layouts/admin.html.erb`](diffhunk://#diff-9fc91735fae00b113814072ed1438c53d5cf484a66c6710bc1f94f6e7d48a3f1L11-R11): Changed the Turbo.js refresh method from `replace` to `morph` and the scroll option from `preserve` to `reset`.