### PR TITLE
STORM_F (feat): add update user firrts name in cabinet page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -24,6 +24,7 @@ class ProfilesController < ApplicationController
       bypass_sign_in(@user) if edit_partial == 'edit_profile_password'
       render turbo_stream: [
         turbo_stream.replace('profile_page', partial: 'profiles/form', locals: { user: @user }),
+        turbo_stream.update('hello_user', partial: 'profiles/user_greetings', locals: { user: @user }),
         turbo_stream.prepend('flash', partial: 'dredd/shared/flash')
       ]
     else

--- a/app/views/dredd/dashboard/index.html.erb
+++ b/app/views/dredd/dashboard/index.html.erb
@@ -1,7 +1,10 @@
 </br>
-</br>
-</br>
 <div class="main-content main-content-padding">
+  <div class="text-2xl text-gray-800 font-medium">
+    <%= t("dredd.user_profile.hello") %>, <%= current_user.first_name %>! 👋
+  </div>
+  </br>
+  </br>
   <div class="">
     <% if policy(:admin).admin_only_access? %>
       <div class="card mb-5 metrics-item">

--- a/app/views/profiles/_user_greetings.html.erb
+++ b/app/views/profiles/_user_greetings.html.erb
@@ -1,0 +1,3 @@
+<div class="text-2xl text-gray-800 font-medium">
+  <%= t("dredd.user_profile.hello") %>, <%= @user.first_name %>! 👋
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,8 +1,8 @@
 <div class="w-full max-w-screen-2xl mx-auto px-7 md:px-16 lg:px-24 mt-20">
   <div class="w-full lg:w-2/3">
-    <div class="text-2xl text-gray-800 font-medium">
-      <%=t("dredd.user_profile.hello") %>, <%= current_user.first_name %>! 👋
-    </div>
-      <%= render 'form' %>
+    <%= turbo_frame_tag "hello_user" do %>
+      <%= render "user_greetings" %>
+    <% end %>
+    <%= render "form" %>
   </div>
 </div>


### PR DESCRIPTION
<img width="926" alt="image" src="https://github.com/Shabaldas/storm_esbuild/assets/33484674/50435f40-be69-4ebd-ad95-8020c1181970">

#### COPILOT AI DESCRIPTION:
This pull request primarily focuses on refactoring the user greeting system in the application. The changes involve extracting the user greeting into a separate partial and updating it dynamically using Turbo Streams. Here are the key changes:

User greeting extraction:

* [`app/views/profiles/_user_greetings.html.erb`](diffhunk://#diff-05b28a76a4d63811c57a86c8080dccb049612d88ab3ffbfc1865ba1f7e680000R1-R3): A new partial was created to hold the user greeting. This allows the greeting to be reused and updated independently.

User greeting updates:

* [`app/controllers/profiles_controller.rb`](diffhunk://#diff-7a47d335107fc35c2e79cc9c2b0a195c863594dd2343bcd48a4c770ac4af673cR27): The `handle_update_action` method was updated to send a Turbo Stream action to update the user greeting whenever a profile update occurs.
* [`app/views/profiles/show.html.erb`](diffhunk://#diff-64807e65095290f37cffcfa9232f887f63a6cd7d3d36c764c3bb04e4bd65b04eL3-R6): The user greeting in the profile show view was replaced with a Turbo Frame. This allows the greeting to be updated independently of the rest of the page.

User greeting display:

* [`app/views/dredd/dashboard/index.html.erb`](diffhunk://#diff-8ef9ba05c137fb03a61106e9de2287037fdfa009602e0b0474ca97b0688016cfR2-L4): The user greeting was added to the dashboard view. This ensures the user is greeted whenever they visit the dashboard.