### PR TITLE
STORM_F (feat): add caclulator loader

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -524,3 +524,27 @@ input[type="checkbox"] {
   border: 1px solid #f5f5f5;
   background-color: #ffffff;
 }
+
+.loader {
+	border-top-color: #3498db;
+	-webkit-animation: spinner 1.5s linear infinite;
+	animation: spinner 1.5s linear infinite;
+}
+
+@-webkit-keyframes spinner {
+	0% {
+		-webkit-transform: rotate(0deg);
+	}
+	100% {
+		-webkit-transform: rotate(360deg);
+	}
+}
+
+@keyframes spinner {
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/app/javascript/controllers/calculator_controller.js
+++ b/app/javascript/controllers/calculator_controller.js
@@ -11,6 +11,26 @@ export default class extends Controller {
     "axesContainer"
   ]
 
+  connect() {
+    document.addEventListener("turbo:submit-start", this._handleStart.bind(this));
+    document.addEventListener("turbo:submit-end", this._handleEnd.bind(this));
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:submit-start", this._handleStart.bind(this));
+    document.removeEventListener("turbo:submit-end", this._handleEnd.bind(this));
+  }
+
+  _handleStart() {
+    const loaderController = this.application.getControllerForElementAndIdentifier(document.getElementById("loader"), "loader");
+    loaderController.show();
+  }
+
+  _handleEnd() {
+    const loaderController = this.application.getControllerForElementAndIdentifier(document.getElementById("loader"), "loader");
+    loaderController.hide();
+  }
+
   initialize() {
     this.stlObject = null
     this.color = 0xDDDDDD

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -84,3 +84,6 @@ application.register('password-visibility', PasswordVisibility)
 
 import TextareaAutogrow from 'stimulus-textarea-autogrow'
 application.register('textarea-autogrow', TextareaAutogrow)
+
+import LoaderController from "./loader_controller";
+application.register("loader", LoaderController);

--- a/app/javascript/controllers/loader_controller.js
+++ b/app/javascript/controllers/loader_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    console.log("Loader controller connected");
+  }
+
+  show() {
+    this.element.classList.remove("hidden");
+  }
+
+  hide() {
+    this.element.classList.add("hidden");
+  }
+}

--- a/app/views/print_models/_form.html.erb
+++ b/app/views/print_models/_form.html.erb
@@ -5,6 +5,15 @@
         <%= f.input :id, as: :hidden, input_html: { value: @print_model.id, id: @print_model.id } %>
       <% end %>
     </div>
+
+    <div id="loader" class="hidden" data-controller="loader">
+      <div wire:loading class="fixed top-0 left-0 right-0 bottom-0 w-full h-screen z-50 overflow-hidden bg-gray-700 opacity-75 flex flex-col items-center justify-center">
+        <div class="loader ease-linear rounded-full border-4 border-t-4 border-gray-200 h-12 w-12 mb-4"></div>
+        <h2 class="text-center text-white text-xl font-semibold">Loading...</h2>
+        <p class="w-1/3 text-center text-white">This may take a few seconds, please don't close this page.</p>
+      </div>
+    </div>
+
     <%= f.input :size, as: :hidden, input_html: { data: { calculator_target: "sizeField" } } %>
     <%= f.input :weight, as: :hidden, input_html: { data: { calculator_target: "weightField" } } %>
     <%= f.input :volume, as: :hidden, input_html: { data: { calculator_target: "volumeField" } } %>


### PR DESCRIPTION
<img width="1697" alt="image" src="https://github.com/Shabaldas/storm_esbuild/assets/33484674/43ff535e-ccfc-4921-8378-38a0ee378632">


### COPILOT AI DESCRIPTION:
This pull request primarily focuses on implementing a loading spinner in the application. The changes include adding CSS for the loader, incorporating the loader in the form, creating a new loader controller, and modifying existing JavaScript controllers to handle the loader's show and hide functionality.

Changes related to the loading spinner:

* [`app/assets/stylesheets/application.tailwind.css`](diffhunk://#diff-ee8509ba5aa9e2a137d0afa09424098c9f2448b66fa955465690c540a47972ebR527-R550): Added CSS for the loader, including keyframes for the spinning animation.
* [`app/views/print_models/_form.html.erb`](diffhunk://#diff-b2ef93beaedc7a844bb0e387f45d9d3a118add3b768a66c6866728e4aafe52d0R8-R16): Incorporated a loading spinner in the form, which is controlled by the new `loader` controller.
* [`app/javascript/controllers/loader_controller.js`](diffhunk://#diff-9827cc1977ce48a568b5f402140896932bc695df58a0f73c2a7fa7b733d18826R1-R15): Created a new `loader` controller responsible for showing and hiding the loading spinner.
* [`app/javascript/controllers/index.js`](diffhunk://#diff-8f62f8b8d3dfa49981cbe3fe5bf80154bc3ad7b34b48b288f6ea52ae230376aeR87-R89): Registered the new `loader` controller.
* [`app/javascript/controllers/calculator_controller.js`](diffhunk://#diff-19d3e148be51700307505a3631582b4fb7bb80925e0e8fd411057a11b49ea9a2R14-R33): Modified the existing `calculator` controller to show the loader when a form submission starts and hide it when the submission ends.